### PR TITLE
[BE-20] Adding nullable field support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 AllCops:
   TargetRubyVersion: 3.2.0
   NewCops: enable
+  SuggestExtensions: false
 
 Style/StringLiterals:
   Enabled: true
@@ -20,3 +21,12 @@ Metrics/BlockLength:
 Style/OpenStructUse:
   Exclude:
     - spec/**/*
+
+Layout/FirstHashElementIndentation:
+  EnforcedStyle: consistent
+
+Layout/FirstArrayElementIndentation:
+  EnforcedStyle: consistent
+
+Metrics/AbcSize:
+  Enabled: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    activemodel-entity (0.2.0)
+    activemodel-entity (0.2.1)
       actionpack (>= 7)
       activemodel (>= 7)
       activesupport (>= 7)

--- a/lib/active_model/entity/version.rb
+++ b/lib/active_model/entity/version.rb
@@ -2,6 +2,6 @@
 
 module ActiveModel
   module Entity
-    VERSION = "0.2.1"
+    VERSION = "0.3.0"
   end
 end

--- a/spec/active_model/entity/schemas/json_spec.rb
+++ b/spec/active_model/entity/schemas/json_spec.rb
@@ -21,31 +21,40 @@ module SchemasTest
     attribute :field_string, :string
     attribute :field_time, :time
     attribute :field_role, :entity, class_name: "SchemasTest::Role"
+    attribute :field_nullable_role, :entity, class_name: "SchemasTest::Role"
     attribute :field_roles, :array, of: "SchemasTest::Role"
     attribute :field_integers, :array, of: :integer
     attribute :field_without_type
+    attribute :field_nullable_string, :string
 
     validates :field_boolean, presence: true
     validates :field_float, presence: true
+    validates :field_nullable_string, presence: { allow_nil: true }
+    validates :field_nullable_role, presence: { allow_nil: true }
   end
 end
 
 RSpec.describe ActiveModel::Entity::Schemas::JSON do
   it "works" do
     schema = SchemasTest::Person.as_json_schema
+
+    properties = { "fieldBigInteger" => { type: :number },
+                   "fieldBoolean" => { type: :boolean },
+                   "fieldDate" => { type: :string },
+                   "fieldDatetime" => { type: :string },
+                   "fieldFloat" => { type: :number },
+                   "fieldInteger" => { type: :number },
+                   "fieldString" => { type: :string },
+                   "fieldTime" => { type: :string },
+                   "fieldRole" => { :$ref => "#/components/schemas/SchemasTest.Role" },
+                   "fieldNullableRole" => { :$ref => "#/components/schemas/SchemasTest.Role", nullable: true },
+                   "fieldRoles" => { items: { :$ref => "#/components/schemas/SchemasTest.Role" }, type: :array },
+                   "fieldIntegers" => { items: { type: :number }, type: :array },
+                   "fieldNullableString" => { type: %i[string null] },
+                   "fieldWithoutType" => { type: :object } }
+
     expect(schema).to eq({ type: :object,
                            required: %w[fieldBoolean fieldFloat],
-                           properties: { "fieldBigInteger" => { type: :number },
-                                         "fieldBoolean" => { type: :boolean },
-                                         "fieldDate" => { type: :string },
-                                         "fieldDatetime" => { type: :string },
-                                         "fieldFloat" => { type: :number },
-                                         "fieldInteger" => { type: :number },
-                                         "fieldString" => { type: :string },
-                                         "fieldTime" => { type: :string },
-                                         "fieldRole" => { :$ref => "#/components/schemas/SchemasTest.Role" },
-                                         "fieldRoles" => { items: { :$ref => "#/components/schemas/SchemasTest.Role" }, type: :array },
-                                         "fieldIntegers" => { items: { type: :number }, type: :array },
-                                         "fieldWithoutType" => { type: :object } } })
+                           properties: })
   end
 end

--- a/spec/active_model/entity/serializers/json_spec.rb
+++ b/spec/active_model/entity/serializers/json_spec.rb
@@ -49,57 +49,57 @@ RSpec.describe ActiveModel::Entity::Serializers::JSON do
       json = SerializersTest::Person.represent(source)
 
       expect(json.deep_symbolize_keys).to eq({
-                                               fieldObj: { x: 1 },
-                                               fieldBigInteger: 137,
-                                               fieldBoolean: false,
-                                               fieldDate: Date.new(2024, 1, 1),
-                                               fieldDatetime: DateTime.new(2024, 1, 1, 1, 3, 7),
-                                               fieldFloat: 1.37,
-                                               fieldInteger: 138,
-                                               fieldString: "string",
-                                               fieldTime: Time.new(2024, 1, 1, 1, 3, 8),
-                                               fieldRole: { fieldName: "nom" },
-                                               fieldRoles: [{ fieldName: "prenom" }],
-                                               fieldIntegers: [1, 3, 7]
-                                             })
+        fieldObj: { x: 1 },
+        fieldBigInteger: 137,
+        fieldBoolean: false,
+        fieldDate: Date.new(2024, 1, 1),
+        fieldDatetime: DateTime.new(2024, 1, 1, 1, 3, 7),
+        fieldFloat: 1.37,
+        fieldInteger: 138,
+        fieldString: "string",
+        fieldTime: Time.new(2024, 1, 1, 1, 3, 8),
+        fieldRole: { fieldName: "nom" },
+        fieldRoles: [{ fieldName: "prenom" }],
+        fieldIntegers: [1, 3, 7]
+      })
     end
   end
 
   context "representing an object" do
     let(:source) do
       OpenStruct.new({
-                       field_obj: { x: 1 },
-                       field_big_integer: 137,
-                       field_boolean: false,
-                       field_date: Date.new(2024, 1, 1),
-                       field_datetime: DateTime.new(2024, 1, 1, 1, 3, 7),
-                       field_float: 1.37,
-                       field_integer: 138,
-                       field_string: "string",
-                       field_time: Time.new(2024, 1, 1, 1, 3, 8),
-                       field_role: OpenStruct.new({ field_name: "nom" }),
-                       field_roles: [OpenStruct.new({ field_name: "prenom" })],
-                       field_integers: [1, 3, 7]
-                     })
+        field_obj: { x: 1 },
+        field_big_integer: 137,
+        field_boolean: false,
+        field_date: Date.new(2024, 1, 1),
+        field_datetime: DateTime.new(2024, 1, 1, 1, 3, 7),
+        field_float: 1.37,
+        field_integer: 138,
+        field_string: "string",
+        field_time: Time.new(2024, 1, 1, 1, 3, 8),
+        field_role: OpenStruct.new({ field_name: "nom" }),
+        field_roles: [OpenStruct.new({ field_name: "prenom" })],
+        field_integers: [1, 3, 7]
+      })
     end
 
     it "represents as JSON" do
       json = SerializersTest::Person.represent(source)
 
       expect(json.deep_symbolize_keys).to eq({
-                                               fieldObj: { x: 1 },
-                                               fieldBigInteger: 137,
-                                               fieldBoolean: false,
-                                               fieldDate: Date.new(2024, 1, 1),
-                                               fieldDatetime: DateTime.new(2024, 1, 1, 1, 3, 7),
-                                               fieldFloat: 1.37,
-                                               fieldInteger: 138,
-                                               fieldString: "string",
-                                               fieldTime: Time.new(2024, 1, 1, 1, 3, 8),
-                                               fieldRole: { fieldName: "nom" },
-                                               fieldRoles: [{ fieldName: "prenom" }],
-                                               fieldIntegers: [1, 3, 7]
-                                             })
+        fieldObj: { x: 1 },
+        fieldBigInteger: 137,
+        fieldBoolean: false,
+        fieldDate: Date.new(2024, 1, 1),
+        fieldDatetime: DateTime.new(2024, 1, 1, 1, 3, 7),
+        fieldFloat: 1.37,
+        fieldInteger: 138,
+        fieldString: "string",
+        fieldTime: Time.new(2024, 1, 1, 1, 3, 8),
+        fieldRole: { fieldName: "nom" },
+        fieldRoles: [{ fieldName: "prenom" }],
+        fieldIntegers: [1, 3, 7]
+      })
     end
   end
 end


### PR DESCRIPTION
## TLDR
```ruby
class MyEntity
  attribute :name, :string
  validates :name, presence: { allow_nil: true }
end
```

## Summary of changes
This PR allows us to define any field as nullable – be it a primitive type like `string` or a reference to another entity.

## Known issues
It seems to be unfeasible to support arrays with nullable elements – at least `openapi-typescript-codegen` does not seem to do anything about these. The use-case, however, is pretty rare, so hopefully we won't need these.