### PR TITLE
[BE-27] Adding support for ::desc method

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,3 +30,6 @@ Layout/FirstArrayElementIndentation:
 
 Metrics/AbcSize:
   Enabled: false
+
+Metrics/MethodLength:
+  Max: 16

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    activemodel-entity (0.2.1)
+    activemodel-entity (0.3.0)
       actionpack (>= 7)
       activemodel (>= 7)
       activesupport (>= 7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    activemodel-entity (0.3.0)
+    activemodel-entity (0.4.1)
       actionpack (>= 7)
       activemodel (>= 7)
       activesupport (>= 7)

--- a/lib/active_model/entity.rb
+++ b/lib/active_model/entity.rb
@@ -9,6 +9,7 @@ require_relative "entity/type"
 require_relative "entity/parsers/json"
 require_relative "entity/serializers/json"
 require_relative "entity/schemas/json"
+require_relative "entity/meta/descriptions"
 
 module ActiveModel
   # Main module providing all neccesary includes to bring missing functionality to ActiveModel instances.
@@ -22,6 +23,7 @@ module ActiveModel
       include ActiveModel::Entity::Parsers::JSON
       include ActiveModel::Entity::Serializers::JSON
       include ActiveModel::Entity::Schemas::JSON
+      include ActiveModel::Entity::Meta::Descriptions
     end
   end
 end

--- a/lib/active_model/entity/meta.rb
+++ b/lib/active_model/entity/meta.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module ActiveModel
+  module Entity
+    # Module containing metadata-related helpers and functions.
+    module Meta
+    end
+  end
+end

--- a/lib/active_model/entity/meta/descriptions.rb
+++ b/lib/active_model/entity/meta/descriptions.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module ActiveModel
+  module Entity
+    module Meta
+      # Provides helper routines allowing ActiveModel::Entity to specify descriptions on the attributes and the entity.
+      module Descriptions
+        extend ActiveSupport::Concern
+
+        included do
+          class_attribute :meta_descriptions, default: {}
+        end
+
+        # Class-level methods.
+        module ClassMethods
+          # Specifies the description for the next defined attribute.
+          # If the call to ::desc is followed by another call, the first one becomes class description.
+          def desc(comment)
+            meta_descriptions[nil] ||= []
+            meta_descriptions[nil] << comment
+          end
+
+          # Intercepts calls to ::attribute method updating meta_descriptions dictionary.
+          def attribute(name, ...)
+            pending_comments = meta_descriptions[nil] || []
+            last_comment = pending_comments.pop
+
+            meta_descriptions[name.to_sym] = last_comment if last_comment
+            super
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/active_model/entity/meta/descriptions.rb
+++ b/lib/active_model/entity/meta/descriptions.rb
@@ -8,7 +8,7 @@ module ActiveModel
         extend ActiveSupport::Concern
 
         included do
-          class_attribute :meta_descriptions, default: {}
+          class_attribute :meta_descriptions, default: { nil => [] }
         end
 
         # Class-level methods.
@@ -16,13 +16,12 @@ module ActiveModel
           # Specifies the description for the next defined attribute.
           # If the call to ::desc is followed by another call, the first one becomes class description.
           def desc(comment)
-            meta_descriptions[nil] ||= []
             meta_descriptions[nil] << comment
           end
 
           # Intercepts calls to ::attribute method updating meta_descriptions dictionary.
           def attribute(name, ...)
-            pending_comments = meta_descriptions[nil] || []
+            pending_comments = meta_descriptions[nil]
             last_comment = pending_comments.pop
 
             meta_descriptions[name.to_sym] = last_comment if last_comment

--- a/lib/active_model/entity/schemas/json.rb
+++ b/lib/active_model/entity/schemas/json.rb
@@ -56,7 +56,7 @@ module ActiveModel
 
           def as_json_schema
             type = :object
-            description = (meta_descriptions[nil] || []).first
+            description = meta_descriptions[nil].first
             required = required_attributes.map(&:name).map { _1.camelize(:lower) }
             nullable = nullable_attributes.map(&:name).index_by { _1.camelize(:lower) }
 
@@ -68,7 +68,7 @@ module ActiveModel
               append_description_if_available!(name, options)
             end
 
-            { type:, description:, required:, properties: }.reject { _2.nil? }
+            { type:, description:, required:, properties: }.compact
           end
         end
       end

--- a/lib/active_model/entity/schemas/json.rb
+++ b/lib/active_model/entity/schemas/json.rb
@@ -49,8 +49,14 @@ module ActiveModel
             options[:nullable] = true if options[:$ref]
           end
 
+          def append_description_if_available!(name, options)
+            key = name.underscore.to_sym
+            options[:description] = meta_descriptions[key] if meta_descriptions.key?(key)
+          end
+
           def as_json_schema
             type = :object
+            description = (meta_descriptions[nil] || []).first
             required = required_attributes.map(&:name).map { _1.camelize(:lower) }
             nullable = nullable_attributes.map(&:name).index_by { _1.camelize(:lower) }
 
@@ -59,9 +65,10 @@ module ActiveModel
 
             properties.each do |name, options|
               make_schema_nullable!(options) if nullable.key?(name)
+              append_description_if_available!(name, options)
             end
 
-            { type:, required:, properties: }
+            { type:, description:, required:, properties: }.reject { _2.nil? }
           end
         end
       end

--- a/lib/active_model/entity/version.rb
+++ b/lib/active_model/entity/version.rb
@@ -2,6 +2,6 @@
 
 module ActiveModel
   module Entity
-    VERSION = "0.4.0"
+    VERSION = "0.4.1"
   end
 end

--- a/lib/active_model/entity/version.rb
+++ b/lib/active_model/entity/version.rb
@@ -2,6 +2,6 @@
 
 module ActiveModel
   module Entity
-    VERSION = "0.3.0"
+    VERSION = "0.4.0"
   end
 end

--- a/spec/active_model/entity/meta/descriptions_spec.rb
+++ b/spec/active_model/entity/meta/descriptions_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "ostruct"
+
+module DescriptionsTest
+  class Role
+    include ActiveModel::Entity
+
+    desc "This is my class"
+
+    desc "This is my attribute"
+    attribute :field_name, :string
+
+    desc "This is my other attribute"
+    attribute :other_field_name, :string
+  end
+end
+
+RSpec.describe ActiveModel::Entity::Meta::Descriptions do
+  it "works" do
+    schema = DescriptionsTest::Role.as_json_schema
+
+    properties = { "fieldName" => { type: :string, description: "This is my attribute" },
+                   "otherFieldName" => { type: :string, description: "This is my other attribute" } }
+
+    expect(schema).to eq({ type: :object,
+                           description: "This is my class",
+                           required: %w[],
+                           properties: })
+  end
+end


### PR DESCRIPTION
This PR enables our gem to supply `description` field to JSON schemas, on both attributes and entities.

Example:

```ruby
class Role
  include ActiveModel::Entity

  desc "This is my class"

  desc "This is my attribute"
  attribute :field_name, :string

  desc "This is my other attribute"
  attribute :other_field_name, :string
end
```

**Caveat** if one specifies a class-level `desc`, if has to be either placed very last OR followed by another `desc` – the `attribute` method consumes whatever last call to `desc` defines. This seems to be a nit since if you are describing an entity, you would probably describe attributes too, but nevertheless it seems to be important sense to mention that.