### PR TITLE
[BE-29] Adding support for enum config

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    activemodel-entity (0.4.1)
+    activemodel-entity (0.4.2)
       actionpack (>= 7)
       activemodel (>= 7)
       activesupport (>= 7)

--- a/lib/active_model/entity/version.rb
+++ b/lib/active_model/entity/version.rb
@@ -2,6 +2,6 @@
 
 module ActiveModel
   module Entity
-    VERSION = "0.4.1"
+    VERSION = "0.4.2"
   end
 end

--- a/spec/active_model/entity/schemas/json_spec.rb
+++ b/spec/active_model/entity/schemas/json_spec.rb
@@ -11,7 +11,6 @@ module SchemasTest
   class Person
     include ActiveModel::Entity
 
-    # attribute :field_obj
     attribute :field_big_integer, :big_integer
     attribute :field_boolean, :boolean
     attribute :field_date, :date
@@ -26,11 +25,15 @@ module SchemasTest
     attribute :field_integers, :array, of: :integer
     attribute :field_without_type
     attribute :field_nullable_string, :string
+    attribute :field_enum_string, :string
+    attribute :field_enum_int, :integer
 
     validates :field_boolean, presence: true
     validates :field_float, presence: true
     validates :field_nullable_string, presence: { allow_nil: true }
     validates :field_nullable_role, presence: { allow_nil: true }
+    validates :field_enum_string, inclusion: { in: %w[an enum] }
+    validates :field_enum_int, inclusion: { in: [1, 3, 7] }
   end
 end
 
@@ -51,7 +54,9 @@ RSpec.describe ActiveModel::Entity::Schemas::JSON do
                    "fieldRoles" => { items: { :$ref => "#/components/schemas/SchemasTest.Role" }, type: :array },
                    "fieldIntegers" => { items: { type: :number }, type: :array },
                    "fieldNullableString" => { type: %i[string null] },
-                   "fieldWithoutType" => { type: :object } }
+                   "fieldWithoutType" => { type: :object },
+                   "fieldEnumString" => { type: :string, enum: %w[an enum] },
+                   "fieldEnumInt" => { type: :number, enum: [1, 3, 7] } }
 
     expect(schema).to eq({ type: :object,
                            required: %w[fieldBoolean fieldFloat],


### PR DESCRIPTION
Apparently, `openapi-typescript-codegen` supports enums, so let's add that for stricter API schema