### PR TITLE
[BE-47] Fixing meta description leak

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    activemodel-entity (0.4.2)
+    activemodel-entity (0.4.3)
       actionpack (>= 7)
       activemodel (>= 7)
       activesupport (>= 7)

--- a/lib/active_model/entity/meta/descriptions.rb
+++ b/lib/active_model/entity/meta/descriptions.rb
@@ -13,6 +13,14 @@ module ActiveModel
 
         # Class-level methods.
         module ClassMethods
+          # Handle inheritance by clonning meta_descriptions value
+          def inherited(subclass)
+            super
+
+            subclass.meta_descriptions = meta_descriptions.dup
+            subclass.meta_descriptions[nil] = []
+          end
+
           # Specifies the description for the next defined attribute.
           # If the call to ::desc is followed by another call, the first one becomes class description.
           def desc(comment)

--- a/lib/active_model/entity/version.rb
+++ b/lib/active_model/entity/version.rb
@@ -2,6 +2,6 @@
 
 module ActiveModel
   module Entity
-    VERSION = "0.4.2"
+    VERSION = "0.4.3"
   end
 end


### PR DESCRIPTION
Rookie's mistake: default value gets set into all subclasses, leading to descriptions being fcked up.