### PR TITLE
[BE-173] Separate flag to track required attributes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    activemodel-entity (0.5.0)
+    activemodel-entity (0.6.0)
       actionpack (>= 7)
       activemodel (>= 7)
       activesupport (>= 7)

--- a/lib/active_model/entity/schemas/json.rb
+++ b/lib/active_model/entity/schemas/json.rb
@@ -23,7 +23,7 @@ module ActiveModel
 
           def required_attributes
             presence_validators = validators.group_by(&:class)[ActiveModel::Validations::PresenceValidator].to_a
-            presence_validators = presence_validators.reject { _1.options[:allow_nil] }
+            presence_validators = presence_validators.reject { _1.options[:required] == false }
             presence_validators.flat_map(&:attributes).to_a
           end
 

--- a/lib/active_model/entity/version.rb
+++ b/lib/active_model/entity/version.rb
@@ -2,6 +2,6 @@
 
 module ActiveModel
   module Entity
-    VERSION = "0.5.0"
+    VERSION = "0.6.0"
   end
 end

--- a/spec/active_model/entity/schemas/json_spec.rb
+++ b/spec/active_model/entity/schemas/json_spec.rb
@@ -21,17 +21,21 @@ module SchemasTest
     attribute :field_time, :time
     attribute :field_role, :entity, class_name: "SchemasTest::Role"
     attribute :field_nullable_role, :entity, class_name: "SchemasTest::Role"
+    attribute :field_nullable_not_required_role, :entity, class_name: "SchemasTest::Role"
     attribute :field_roles, :array, of: "SchemasTest::Role"
     attribute :field_integers, :array, of: :integer
     attribute :field_without_type
     attribute :field_nullable_string, :string
+    attribute :field_nullable_not_required_string, :string
     attribute :field_enum_string, :string
     attribute :field_enum_int, :integer
 
     validates :field_boolean, presence: true
     validates :field_float, presence: true
     validates :field_nullable_string, presence: { allow_nil: true }
+    validates :field_nullable_not_required_string, presence: { allow_nil: true, required: false }
     validates :field_nullable_role, presence: { allow_nil: true }
+    validates :field_nullable_not_required_role, presence: { allow_nil: true, required: false }
     validates :field_enum_string, inclusion: { in: %w[an enum] }
     validates :field_enum_int, inclusion: { in: [1, 3, 7] }
   end
@@ -51,15 +55,19 @@ RSpec.describe ActiveModel::Entity::Schemas::JSON do
                    "fieldTime" => { type: :string },
                    "fieldRole" => { :$ref => "#/components/schemas/SchemasTest.Role" },
                    "fieldNullableRole" => { :$ref => "#/components/schemas/SchemasTest.Role", nullable: true },
+                   "fieldNullableNotRequiredRole" => { :$ref => "#/components/schemas/SchemasTest.Role", nullable: true },
                    "fieldRoles" => { items: { :$ref => "#/components/schemas/SchemasTest.Role" }, type: :array },
                    "fieldIntegers" => { items: { type: :number }, type: :array },
                    "fieldNullableString" => { type: %i[string null] },
+                   "fieldNullableNotRequiredString" => { type: %i[string null] },
                    "fieldWithoutType" => { type: :object },
                    "fieldEnumString" => { type: :string, enum: %w[an enum] },
                    "fieldEnumInt" => { type: :number, enum: [1, 3, 7] } }
 
-    expect(schema).to eq({ type: :object,
-                           required: %w[fieldBoolean fieldFloat],
-                           properties: })
+    expect(schema).to eq({
+      type: :object,
+      required: %w[fieldBoolean fieldFloat fieldNullableString fieldNullableRole],
+      properties:
+    })
   end
 end


### PR DESCRIPTION
It's a breaking change:

prev:
```ruby
validates :field, presence: { allow_nil: true }
``` 
Did not add  `:field` into required list and add `NULL` as possible value

After this PR it will add it into required attributes, to avoid it we just need to add one more flag:

```Ruby
validates :field, presence: { allow_nil: true, required: false }
```

It's done intentionally, but feel free to ask me to change it to smth like (but suggest name for the option pls):

```Ruby
validates :field, presence: { allow_nil: true, skip: true }
```