### PR TITLE
[BE-196] Replace null type with nullable

### DIFF
--- a/lib/active_model/entity/schemas/json.rb
+++ b/lib/active_model/entity/schemas/json.rb
@@ -56,8 +56,7 @@ module ActiveModel
           end
 
           def make_schema_nullable!(options)
-            options[:type] = [options[:type], :null] if options[:type]
-            options[:nullable] = true if options[:$ref]
+            options[:nullable] = true
           end
 
           def append_description_if_available!(name, options)

--- a/spec/active_model/entity/schemas/json_spec.rb
+++ b/spec/active_model/entity/schemas/json_spec.rb
@@ -58,8 +58,8 @@ RSpec.describe ActiveModel::Entity::Schemas::JSON do
                    "fieldNullableNotRequiredRole" => { :$ref => "#/components/schemas/SchemasTest.Role", nullable: true },
                    "fieldRoles" => { items: { :$ref => "#/components/schemas/SchemasTest.Role" }, type: :array },
                    "fieldIntegers" => { items: { type: :number }, type: :array },
-                   "fieldNullableString" => { type: %i[string null] },
-                   "fieldNullableNotRequiredString" => { type: %i[string null] },
+                   "fieldNullableString" => { type: :string, nullable: true },
+                   "fieldNullableNotRequiredString" => { type: :string, nullable: true },
                    "fieldWithoutType" => { type: :object },
                    "fieldEnumString" => { type: :string, enum: %w[an enum] },
                    "fieldEnumInt" => { type: :number, enum: [1, 3, 7] } }


### PR DESCRIPTION
It allows us to get typed arrays in TS instead of
```
any[] | null
```
It works with basic types and custom classes as well
