### PR TITLE
[DEV-7] Add serialization for Entities

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,4 @@ gem "rspec", "~> 3.0"
 gem "rubocop", "~> 1.21"
 
 # Security
-gem "rexml", ">= 3.2.8"
+gem "rexml", ">= 3.3.6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,8 +88,7 @@ GEM
     rainbow (3.1.1)
     rake (13.2.1)
     regexp_parser (2.9.2)
-    rexml (3.3.2)
-      strscan
+    rexml (3.3.9)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -117,7 +116,6 @@ GEM
     rubocop-ast (1.31.3)
       parser (>= 3.3.1.0)
     ruby-progressbar (1.13.0)
-    strscan (3.1.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
@@ -133,7 +131,7 @@ PLATFORMS
 DEPENDENCIES
   activemodel-entity!
   rake (~> 13.0)
-  rexml (>= 3.2.8)
+  rexml (>= 3.3.6)
   rspec (~> 3.0)
   rubocop (~> 1.21)
 

--- a/lib/active_model/entity/attribute.rb
+++ b/lib/active_model/entity/attribute.rb
@@ -1,9 +1,14 @@
 # frozen_string_literal: true
 
-# Patch for ActiveModel::Type::Value to support casting JSON values
+# Patch for ActiveModel::Type::Value
 ActiveModel::Type::Value.class_eval do
   # Add alias to `cast` method for casting JSON values in ActiveModel::Attribute::FromJSON class
   alias_method :cast_json, :cast
+
+  # Serialize value with options, for base ActiveModel::Type::* classes it will delegates to serialize
+  def serialize_with_options(value, _options = {})
+    serialize(value)
+  end
 end
 
 module ActiveModel

--- a/lib/active_model/entity/serializers/json.rb
+++ b/lib/active_model/entity/serializers/json.rb
@@ -7,8 +7,27 @@ module ActiveModel
       module JSON
         extend ActiveSupport::Concern
 
+        included do
+          class_attribute :custom_serializers, default: {}
+        end
+
         # Class-level methods.
         module ClassMethods
+          # Handle inheritance by clonning custom_serializers value
+          def inherited(subclass)
+            super
+
+            subclass.custom_serializers = custom_serializers.dup
+          end
+
+          #
+          # Specifies custom serialization for attribute.
+          # @param attribute [Symbol|String] The attribute to serialize.
+          # @param callable [Proc] The callable to use for serialization. Object or hash and options are passed as arguments.
+          def serialization(attribute, callable)
+            custom_serializers[attribute.to_s] = callable
+          end
+
           def fetch_field_value(object_or_hash, name)
             if object_or_hash.is_a?(Hash)
               object_or_hash[name]
@@ -17,15 +36,32 @@ module ActiveModel
             end
           end
 
-          def represent(object_or_hash, camelize: true)
+          def represent(object_or_hash, options = {})
+            entity_options = default_represent_options.merge(options)
+
+            camelize = entity_options[:camelize]
+
             object_or_hash = object_or_hash.with_indifferent_access if object_or_hash.is_a?(Hash)
 
             attribute_types.each_with_object({}) do |(name, type), memo|
-              json_name = name.camelcase(:lower) if camelize
-              value = fetch_field_value(object_or_hash, name)
-              # FIXME: camelize is not passed down to nested serializers!
-              memo[json_name] = type.serialize(value)
+              json_name = camelize ? name.camelcase(:lower) : name
+
+              custom_serializer = custom_serializers[name]
+
+              value = if custom_serializer.present?
+                        custom_serializer.call(object_or_hash, entity_options)
+                      else
+                        fetch_field_value(object_or_hash, name)
+                      end
+
+              memo[json_name] = type.serialize_with_options(value, options)
             end
+          end
+
+          # Default options for representing an entity.
+          # Override this method to provide custom default options for Entity
+          def default_represent_options
+            { camelize: true }
           end
         end
       end

--- a/lib/active_model/entity/serializers/json.rb
+++ b/lib/active_model/entity/serializers/json.rb
@@ -23,9 +23,9 @@ module ActiveModel
           #
           # Specifies custom serialization for attribute.
           # @param attribute [Symbol|String] The attribute to serialize.
-          # @param callable [Proc] The callable to use for serialization. Object or hash and options are passed as arguments.
-          def serialization(attribute, callable)
-            custom_serializers[attribute.to_s] = callable
+          # @param block [Proc] The block to use for serialization. Object or hash and options are passed as arguments.
+          def serializes(attribute, &block)
+            custom_serializers[attribute.to_s] = block
           end
 
           def fetch_field_value(object_or_hash, name)
@@ -48,11 +48,11 @@ module ActiveModel
 
               custom_serializer = custom_serializers[name]
 
-              value = if custom_serializer.present?
-                        custom_serializer.call(object_or_hash, entity_options)
-                      else
-                        fetch_field_value(object_or_hash, name)
-                      end
+              if custom_serializer.present?
+                custom_serializer.call(object_or_hash, entity_options)
+              else
+                fetch_field_value(object_or_hash, name)
+              end => value
 
               memo[json_name] = type.serialize_with_options(value, options)
             end

--- a/lib/active_model/entity/type/array.rb
+++ b/lib/active_model/entity/type/array.rb
@@ -40,10 +40,16 @@ module ActiveModel
           raise NotImplementedError
         end
 
+        # Fallback for direct calls
         def serialize(value)
+          serialize_with_options(value)
+        end
+
+        # Seriaze Array by serializing each element with options
+        def serialize_with_options(value, options = {})
           return nil if value.nil?
 
-          value.map { element_type.serialize(_1) }
+          value.map { element_type.serialize_with_options(_1, options) }
         end
 
         def element_type

--- a/lib/active_model/entity/type/entity.rb
+++ b/lib/active_model/entity/type/entity.rb
@@ -37,10 +37,16 @@ module ActiveModel
           raise NotImplementedError
         end
 
+        # Fallback for direct calls
         def serialize(value)
+          serialize_with_options(value)
+        end
+
+        # Serialize entity with options
+        def serialize_with_options(value, options = {})
           return nil if value.nil?
 
-          entity_type.represent(value)
+          entity_type.represent(value, options)
         end
 
         def entity_type

--- a/spec/active_model/entity/serializers/json_spec.rb
+++ b/spec/active_model/entity/serializers/json_spec.rb
@@ -9,14 +9,11 @@ module SerializersTest
     attribute :field_name_upcase, :string
     attribute :field_name_with_options, :string
 
-    serialization :field_name_upcase, proc { _1.is_a?(Hash) ? _1[:field_name].upcase : _1.field_name.upcase }
-    serialization(
-      :field_name_with_options,
-      proc do |object_or_hash, options|
-        value = object_or_hash.is_a?(Hash) ? object_or_hash[:field_name] : object_or_hash
-        options[:hidden].present? ? "***" : value
-      end
-    )
+    serializes(:field_name_upcase) { _1.is_a?(Hash) ? _1[:field_name].upcase : _1.field_name.upcase }
+    serializes :field_name_with_options do |object_or_hash, options|
+      value = object_or_hash.is_a?(Hash) ? object_or_hash[:field_name] : object_or_hash
+      options[:hidden].present? ? "***" : value
+    end
   end
 
   class Person
@@ -36,7 +33,7 @@ module SerializersTest
     attribute :field_roles, :array, of: "SerializersTest::Role"
     attribute :field_integers, :array, of: :integer
 
-    serialization :field_static_string, proc { "static" }
+    serializes(:field_static_string) { "static" }
   end
 end
 


### PR DESCRIPTION
New class method added for handle custom serialization

Example

```Ruby
class Role
  include ActiveModel::Entity
  attribute :static, :string
  attribute :name, :string
  attribute :name_upcase, :string
  attribute :name_with_options, :string

  serialization :static, proc { 'constant' }
  serialization :name_upcase, proc { _1.is_a?(Hash) ? _1[:name].upcase : _1.name.upcase }
  serialization(
    :name_with_options,
    proc do |object_or_hash, options|
      value = object_or_hash.is_a?(Hash) ? object_or_hash[:name] : object_or_hash
      options[:hidden].present? ? "***" : value
    end
  )
end
```

Some examples:

1. default usage
```Ruby
puts Role.represent({name: 'Bob'})
```
```JSON
{
  "static": "constant",
  "name": "Bob"
  "nameUpcase": "BOB",
  "nameWithOptions": "Bob"
}
```

2. With new options
```Ruby
puts Role.represent({name: 'Bob'}, hidden: true)
```
```JSON
{
  "static": "constant",
  "name": "Bob"
  "nameUpcase": "BOB",
  "nameWithOptions": "***"
}
```

3. With `camelize` toggle
```Ruby
puts Role.represent({name: 'Bob'}, camelize: false)
```
```JSON
{
  "static": "constant",
  "name": "Bob"
  "name_upcase": "BOB",
  "name_with_options": "Bob"
}
```

